### PR TITLE
feat: 웹 서버 연동을 위한 프론트 API 구조(apiClient / React Query) 및 공통 유틸 초기 세팅

### DIFF
--- a/Mongle-admin-web/src/constants/apiMessages.js
+++ b/Mongle-admin-web/src/constants/apiMessages.js
@@ -1,0 +1,8 @@
+export const API_MESSAGES = {
+  FETCH_FAILED: '데이터 조회에 실패했습니다.',
+  CREATE_FAILED: '데이터 생성에 실패했습니다.',
+  UPDATE_FAILED: '데이터 수정에 실패했습니다.',
+  DELETE_FAILED: '데이터 삭제에 실패했습니다.',
+  LOGIN_FAILED: '로그인에 실패했습니다.',
+  SESSION_EXPIRED: '세션이 만료되었습니다. 다시 로그인해주세요.',
+};

--- a/Mongle-admin-web/src/hooks/useRealtimeSubscription.js
+++ b/Mongle-admin-web/src/hooks/useRealtimeSubscription.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+export function useRealtimeSubscription(createSubscription, deps = []) {
+  const cleanupRef = useRef(null);
+
+  useEffect(() => {
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = null;
+    }
+
+    const cleanup = createSubscription?.();
+
+    if (typeof cleanup === 'function') {
+      cleanupRef.current = cleanup;
+    }
+
+    return () => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/Mongle-admin-web/src/lib/api.js
+++ b/Mongle-admin-web/src/lib/api.js
@@ -1,0 +1,25 @@
+import apiClient from './apiClient';
+
+export const api = {
+  // 프로젝트
+  getProjects: () => apiClient.get('/projects'),
+  getProject: (id) => apiClient.get(`/projects/${id}`),
+  createProject: (data) => apiClient.post('/projects', data),
+
+  // 타임라인
+  getTimelines: (projectId) =>
+    apiClient.get(`/timelines/project/${projectId}`),
+  createTimeline: (data) => apiClient.post('/timelines', data),
+
+  // 예산
+  getBudgets: (projectId) =>
+    apiClient.get(`/budgets/project/${projectId}`),
+  createBudget: (data) => apiClient.post('/budgets', data),
+
+  // 업체
+  getVendors: () => apiClient.get('/vendors'),
+
+  // 채팅
+  getChats: (projectId) =>
+    apiClient.get(`/chats/project/${projectId}`),
+};

--- a/Mongle-admin-web/src/lib/apiClient.js
+++ b/Mongle-admin-web/src/lib/apiClient.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import { supabase } from './supabase';
+
+const apiClient = axios.create({
+  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8000',
+});
+
+apiClient.interceptors.request.use(async (config) => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session?.access_token) {
+    config.headers.Authorization = `Bearer ${session.access_token}`;
+  }
+
+  return config;
+});
+
+export default apiClient;

--- a/Mongle-admin-web/src/lib/queryClient.js
+++ b/Mongle-admin-web/src/lib/queryClient.js
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: 1,
+    },
+  },
+});

--- a/Mongle-admin-web/src/lib/queryKeys.js
+++ b/Mongle-admin-web/src/lib/queryKeys.js
@@ -1,0 +1,16 @@
+export const queryKeys = {
+  projects: ['projects'],
+  project: (projectId) => ['project', projectId],
+
+  timelines: (projectId) => ['timelines', projectId],
+  timeline: (timelineId) => ['timeline', timelineId],
+
+  budgets: (projectId) => ['budgets', projectId],
+  budget: (budgetId) => ['budget', budgetId],
+
+  vendors: (projectId) => ['vendors', projectId],
+  vendor: (vendorId) => ['vendor', vendorId],
+
+  chats: (projectId) => ['chats', projectId],
+  chatMessages: (chatId) => ['chatMessages', chatId],
+};

--- a/Mongle-admin-web/src/utils/apiError.js
+++ b/Mongle-admin-web/src/utils/apiError.js
@@ -1,0 +1,26 @@
+export function getApiErrorMessage(error, fallback = '요청 처리 중 오류가 발생했습니다.') {
+  if (!error) return fallback;
+
+  const responseData = error.response?.data;
+
+  if (typeof responseData === 'string' && responseData.trim()) {
+    return responseData;
+  }
+
+  if (responseData?.message) {
+    return responseData.message;
+  }
+
+  if (responseData?.detail) {
+    if (typeof responseData.detail === 'string') return responseData.detail;
+    if (Array.isArray(responseData.detail)) {
+      return responseData.detail.map((item) => item.msg || item.message || '입력 오류').join(', ');
+    }
+  }
+
+  if (error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}

--- a/Mongle-admin-web/src/utils/authListener.js
+++ b/Mongle-admin-web/src/utils/authListener.js
@@ -1,0 +1,15 @@
+import { supabase } from '../lib/supabase';
+
+export function initAuthListener(onChange) {
+  const { data: listener } = supabase.auth.onAuthStateChange(
+    (event, session) => {
+      if (onChange) {
+        onChange({ event, session });
+      }
+    }
+  );
+
+  return () => {
+    listener?.subscription?.unsubscribe();
+  };
+}

--- a/Mongle-admin-web/src/utils/isEmptyValue.js
+++ b/Mongle-admin-web/src/utils/isEmptyValue.js
@@ -1,0 +1,8 @@
+export function isEmptyValue(value) {
+  return (
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}

--- a/Mongle-admin-web/src/utils/logger.js
+++ b/Mongle-admin-web/src/utils/logger.js
@@ -1,0 +1,15 @@
+export const logger = {
+  log: (...args) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[LOG]', ...args);
+    }
+  },
+
+  error: (...args) => {
+    console.error('[ERROR]', ...args);
+  },
+
+  warn: (...args) => {
+    console.warn('[WARN]', ...args);
+  },
+};

--- a/Mongle-admin-web/src/utils/sseClient.js
+++ b/Mongle-admin-web/src/utils/sseClient.js
@@ -1,0 +1,50 @@
+export function createSSEClient({ url, token, onMessage, onError, onOpen }) {
+  let eventSource = null;
+
+  const connect = () => {
+    const finalUrl = token
+      ? `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
+      : url;
+
+    eventSource = new EventSource(finalUrl);
+
+    eventSource.onopen = () => {
+      if (onOpen) onOpen();
+    };
+
+    eventSource.onmessage = (event) => {
+      if (!onMessage) return;
+
+      try {
+        const parsed = JSON.parse(event.data);
+        onMessage(parsed);
+      } catch {
+        onMessage(event.data);
+      }
+    };
+
+    eventSource.onerror = (error) => {
+      if (onError) onError(error);
+      if (eventSource) {
+        eventSource.close();
+      }
+    };
+
+    return eventSource;
+  };
+
+  const close = () => {
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+    }
+  };
+
+  return {
+    connect,
+    close,
+    get instance() {
+      return eventSource;
+    },
+  };
+}


### PR DESCRIPTION
💡 어떤 작업을 하셨나요?
프론트엔드 공통 API 구조 및 유틸 파일 추가
Axios 기반 API 클라이언트(apiClient) 구성 및 Supabase 토큰 자동 첨부 로직 구현
React Query 전역 설정(queryClient) 파일 추가
서버 API 구조에 맞춘 API 레이어(api.js) 구성
공통 Query Key(queryKeys) 정의
인증 상태 변경 감지(authListener) 유틸 추가
공통 에러 처리(apiError) 유틸 추가
기타 유틸 및 확장 구조(sseClient, useRealtimeSubscription 등) 파일 추가

📋 관련 이슈 (Issue)
없음 (구조 개선 및 초기 세팅 작업)

📸 스크린샷 (UI 변경이 있는 경우)
UI 변경 없음

✅ PR 체크리스트
프로젝트 구조에 맞게 파일 생성 위치 확인 (Mongle-admin-web)
불필요한 서버 코드 변경 없음
기존 기능 영향 없음 (파일 추가만 진행)
API 구조가 백엔드(/projects, /timelines, /budgets 등)와 일치하는지 확인
Supabase 토큰 기반 인증 흐름 적용 준비 완료

🔍 리뷰어에게 부탁할 말
현재 PR은 기능 구현이 아닌 프론트 공통 구조 세팅 작업입니다.
이후 API 연동 및 React Query 적용 단계에서 활용될 예정입니다.
apiClient, api.js 구조가 백엔드와 맞는지 확인 부탁드립니다.
추가로 필요한 공통 구조가 있다면 피드백 부탁드립니다.